### PR TITLE
removed extraneous 'params.slug' on pages without a slug param

### DIFF
--- a/pages/blog/author/_author.vue
+++ b/pages/blog/author/_author.vue
@@ -65,7 +65,7 @@
 <script>
 export default {
   async asyncData({ $content, params }) {
-    const articles = await $content('articles', params.slug)
+    const articles = await $content('articles')
       .where({
         'author.name': {
           $regex: [params.author, 'i']

--- a/pages/blog/tag/_tag.vue
+++ b/pages/blog/tag/_tag.vue
@@ -72,7 +72,7 @@ export default {
       .limit(1)
       .fetch()
     const tag = tags.length > 0 ? tags[0] : {}
-    const articles = await $content('articles', params.slug)
+    const articles = await $content('articles')
       .where({ tags: { $contains: tag.name } })
       .sortBy('createdAt', 'asc')
       .fetch()

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -70,11 +70,11 @@
 <script>
 export default {
   async asyncData({ $content, params }) {
-    const articles = await $content('articles', params.slug)
+    const articles = await $content('articles')
       .only(['title', 'description', 'img', 'slug', 'author'])
       .sortBy('createdAt', 'desc')
       .fetch()
-    const tags = await $content('tags', params.slug)
+    const tags = await $content('tags')
       .only(['name', 'description', 'img', 'slug'])
       .sortBy('createdAt', 'asc')
       .fetch()


### PR DESCRIPTION
This PR removes the `params.slug` parameter from `$content()` calls on pages which don't have a `slug` param, such as the **authors** and **tags** pages. The inclusion of this `undefined` parameter doesn't affect the functionality of these pages since `$content()` ignores the `undefined` second parameter. Removing this unnecessary parameter just makes the code easier to understand.